### PR TITLE
Method for NeighborID usage

### DIFF
--- a/rhill-voronoi-core.js
+++ b/rhill-voronoi-core.js
@@ -476,6 +476,7 @@ Voronoi.prototype.RBTree.prototype.getLast = function(node) {
 
 Voronoi.prototype.Cell = function(site) {
 	this.site = site;
+	this.corners   = [];
 	this.halfedges = [];
 	};
 
@@ -510,11 +511,18 @@ Voronoi.prototype.Cell.prototype.prepare = function() {
 	// rhill 2011-05-27: Keep it simple, no point here in trying
 	// to be fancy: dangling edges are a typically a minority.
 	while (iHalfedge--) {
+        this.corners.push(halfedges[iHalfedge].getStartpoint());
 		edge = halfedges[iHalfedge].edge;
 		if (!edge.vb || !edge.va) {
 			halfedges.splice(iHalfedge,1);
 			}
 		}
+    // This is an ugly hack to remove null corners
+    this.corners = this.corners.filter(
+                        function(val) { 
+                            return val !== null; 
+                        });
+
 	// rhill 2011-05-26: I tried to use a binary search at insertion
 	// time to keep the array sorted on-the-fly (in Cell.addHalfedge()).
 	// There was no real benefits in doing so, performance on
@@ -1465,6 +1473,7 @@ Voronoi.prototype.compute = function(sites, bbox) {
 	var result = {
 		cells: this.cells,
 		edges: this.edges,
+		corners: this.corners,
 		execTime: stopTime.getTime()-startTime.getTime()
 		};
 


### PR DESCRIPTION
Probably not very efficient, but the two new methods make it easier to manipulate the map.

First method returns the neighbor IDs for a given cell, and the second randomly selects a neighbor ID.

May or may not be worth integrating.
