### PR TITLE
Use Infinity rather than Number.{MIN_MAX}_VALUE.

### DIFF
--- a/rhill-voronoi-core.js
+++ b/rhill-voronoi-core.js
@@ -469,10 +469,10 @@ Voronoi.prototype.Cell.prototype.getNeighborIds = function() {
 Voronoi.prototype.Cell.prototype.getBbox = function() {
     var halfedges = this.halfedges,
         iHalfedge = halfedges.length,
-        xmin = Number.MAX_VALUE,
-        ymin = Number.MAX_VALUE,
-        xmax = Number.MIN_VALUE,
-        ymax = Number.MIN_VALUE;
+        xmin = Infinity,
+        ymin = Infinity,
+        xmax = -Infinity,
+        ymax = -Infinity;
     while (iHalfedge--) {
         v = halfedges[iHalfedge].getStartpoint();
         vx = v.x;


### PR DESCRIPTION
It’s possible I’m wrong here, but I’m guessing you didn’t mean to use Number.MIN_VALUE (the smallest positive value, 5e-324) to initialize the bounding box. Unless you meant to restrict the Voronoi tesselation to only positive coordinates?
