### PR TITLE
Fix initial duplicate detection.

### DIFF
--- a/rhill-voronoi-core.js
+++ b/rhill-voronoi-core.js
@@ -1428,8 +1428,8 @@ Voronoi.prototype.compute = function(sites, bbox) {
     // process queue
     var site = siteEvents.pop(),
         siteid = 0,
-        xsitex = Number.MIN_VALUE, // to avoid duplicate sites
-        xsitey = Number.MIN_VALUE,
+        xsitex, // to avoid duplicate sites
+        xsitey,
         cells = this.cells,
         circle;
 


### PR DESCRIPTION
When detecting coincident points, the previous site [xsitex, xsitey] should be initialized to an illegal value (different from any potential valid input site). But [Number.MIN_VALUE, Number.MIN_VALUE] is a valid site, so use [undefined, undefined] instead.
