### PR TITLE
Halfedge linked list

### DIFF
--- a/rhill-voronoi-core.js
+++ b/rhill-voronoi-core.js
@@ -419,71 +419,6 @@ Voronoi.prototype.RBTree.prototype.getLast = function(node) {
     };
 
 // ---------------------------------------------------------------------------
-// Linked List
-
-Voronoi.prototype.LinkedList = function() {
-    this.length = 0;
-    this.first  = null;
-    this.last   = null;
-};
-
-Voronoi.prototype.LinkedList.prototype.push = function(element) {
-    if(this.last) {
-        this.last.next = element;
-        element.prev = this.last;
-        this.last = element;
-        }
-    else {
-        this.first = this.last = element;
-        }
-    ++this.length;
-};
-
-Voronoi.prototype.LinkedList.prototype.remove = function(element) {
-    if(element.prev && element.next) {
-        element.prev.next = element.next;
-        element.next.prev = element.prev;
-        }
-    else if(element.prev) {
-        element.prev.next = null;
-        this.last = element.prev;
-        }
-    else if(element.next) {
-        element.next.prev = null;
-        this.first = element.next;
-        }
-
-    --this.length;
-
-    if(!this.length) {
-        this.first = null;
-        this.last  = null;
-        }
-    };
-
-Voronoi.prototype.LinkedList.prototype.insertAfter = function(prev,element) {
-    element.next = prev.next;
-
-    if(prev.next) {
-        prev.next.prev = element;
-        }
-    else {
-        this.last = element;
-        }
-
-    prev.next = element;
-    element.prev = prev;
-
-    ++this.length;
-};
-
-Voronoi.prototype.LinkedList.prototype.reset = function() {
-    this.length = 0;
-    this.first  = null;
-    this.last   = null;
-};
-
-// ---------------------------------------------------------------------------
 // Diagram methods
 
 Voronoi.prototype.Diagram = function(site) {
@@ -619,6 +554,71 @@ Voronoi.prototype.Cell.prototype.pointIntersection = function(x, y) {
         }
     return 1;
     };
+
+// ---------------------------------------------------------------------------
+// Halfedge Linked List
+
+Voronoi.prototype.Cell.prototype.HalfedgeList = function() {
+    this.length = 0;
+    this.first  = null;
+    this.last   = null;
+};
+
+Voronoi.prototype.Cell.prototype.HalfedgeList.prototype.push = function(element) {
+    if(this.last) {
+        this.last.next = element;
+        element.prev = this.last;
+        this.last = element;
+        }
+    else {
+        this.first = this.last = element;
+        }
+    ++this.length;
+};
+
+Voronoi.prototype.Cell.prototype.HalfedgeList.prototype.remove = function(element) {
+    if(element.prev && element.next) {
+        element.prev.next = element.next;
+        element.next.prev = element.prev;
+        }
+    else if(element.prev) {
+        element.prev.next = null;
+        this.last = element.prev;
+        }
+    else if(element.next) {
+        element.next.prev = null;
+        this.first = element.next;
+        }
+
+    --this.length;
+
+    if(!this.length) {
+        this.first = null;
+        this.last  = null;
+        }
+    };
+
+Voronoi.prototype.Cell.prototype.HalfedgeList.prototype.insertAfter = function(prev,element) {
+    element.next = prev.next;
+
+    if(prev.next) {
+        prev.next.prev = element;
+        }
+    else {
+        this.last = element;
+        }
+
+    prev.next = element;
+    element.prev = prev;
+
+    ++this.length;
+};
+
+Voronoi.prototype.Cell.prototype.HalfedgeList.prototype.reset = function() {
+    this.length = 0;
+    this.first  = null;
+    this.last   = null;
+};
 
 // ---------------------------------------------------------------------------
 // Edge methods

--- a/rhill-voronoi-core.js
+++ b/rhill-voronoi-core.js
@@ -419,6 +419,71 @@ Voronoi.prototype.RBTree.prototype.getLast = function(node) {
     };
 
 // ---------------------------------------------------------------------------
+// Linked List
+
+Voronoi.prototype.LinkedList = function() {
+    this.length = 0;
+    this.first  = null;
+    this.last   = null;
+};
+
+Voronoi.prototype.LinkedList.prototype.push = function(element) {
+    if(this.last) {
+        this.last.next = element;
+        element.prev = this.last;
+        this.last = element;
+        }
+    else {
+        this.first = this.last = element;
+        }
+    ++this.length;
+};
+
+Voronoi.prototype.LinkedList.prototype.remove = function(element) {
+    if(element.prev && element.next) {
+        element.prev.next = element.next;
+        element.next.prev = element.prev;
+        }
+    else if(element.prev) {
+        element.prev.next = null;
+        this.last = element.prev;
+        }
+    else if(element.next) {
+        element.next.prev = null;
+        this.first = element.next;
+        }
+
+    --this.length;
+
+    if(!this.length) {
+        this.first = null;
+        this.last  = null;
+        }
+    };
+
+Voronoi.prototype.LinkedList.prototype.insertAfter = function(prev,element) {
+    element.next = prev.next;
+
+    if(prev.next) {
+        prev.next.prev = element;
+        }
+    else {
+        this.last = element;
+        }
+
+    prev.next = element;
+    element.prev = prev;
+
+    ++this.length;
+};
+
+Voronoi.prototype.LinkedList.prototype.reset = function() {
+    this.length = 0;
+    this.first  = null;
+    this.last   = null;
+};
+
+// ---------------------------------------------------------------------------
 // Diagram methods
 
 Voronoi.prototype.Diagram = function(site) {
@@ -1352,7 +1417,7 @@ Voronoi.prototype.clipEdge = function(edge, bbox) {
         if (r>t1) {return false;}
         if (r>t0) {t0=r;}
         }
-    // bottom        
+    // bottom
     q = bbox.yb-ay;
     if (dy===0 && q<0) {return false;}
     r = q/dy;


### PR DESCRIPTION
This PR introduces a HalfedgeList object (a doubly-linked list) to replace arrays in Voronoi cells. It seems a lot of time is spent on garbage collection when the createEdge method is called, since it needs to push new objects to the halfedges array of the corresponding cells.

At least in Chrome and Safari, this change gives a significant speed up when running the benchmark and Lloyd's relaxation demos with 10000 vertices.

Please note that this change would break code that needs to iterate through the existing halfedges array of the cell object though.

Iterating through halfedges would need to be done in this manner:

```
var halfedge = cell.halfedges.first;

while(halfedge) {
    // Do something with the halfedge here
    // ...
    halfedge = halfedge.next;
}
```

Also, the HalfedgeList object is declared within the prototype of the Cell object. I'm not sure whether this is the right way to go or not. I tried declaring this within the prototype of the Voronoi object, like the Cell and Halfedge objects, but couldn't find a way to call the HalfedgeList constructor from within the Cell object's methods.