### PR TITLE
fix performance issue with 16k+ sites

### DIFF
--- a/rhill-voronoi-core.js
+++ b/rhill-voronoi-core.js
@@ -1352,7 +1352,7 @@ Voronoi.prototype.clipEdge = function(edge, bbox) {
         if (r>t1) {return false;}
         if (r>t0) {t0=r;}
         }
-    // bottom        
+    // bottom
     q = bbox.yb-ay;
     if (dy===0 && q<0) {return false;}
     r = q/dy;
@@ -1397,7 +1397,8 @@ Voronoi.prototype.clipEdge = function(edge, bbox) {
 Voronoi.prototype.clipEdges = function(bbox) {
     // connect all dangling edges to bounding box
     // or get rid of them if it can't be done
-    var edges = this.edges,
+    var newEdges = [],
+        edges = this.edges,
         iEdge = edges.length,
         edge,
         abs_fn = Math.abs;
@@ -1413,8 +1414,11 @@ Voronoi.prototype.clipEdges = function(bbox) {
             (abs_fn(edge.va.x-edge.vb.x)<1e-9 && abs_fn(edge.va.y-edge.vb.y)<1e-9)) {
             edge.va = edge.vb = null;
             edges.splice(iEdge,1);
+            } else {
+            newEdges.unshift(edge);
             }
-        }
+      }
+      this.edges = newEdges;
     };
 
 // Close the cells.

--- a/rhill-voronoi-core.js
+++ b/rhill-voronoi-core.js
@@ -1413,7 +1413,6 @@ Voronoi.prototype.clipEdges = function(bbox) {
             !this.clipEdge(edge, bbox) ||
             (abs_fn(edge.va.x-edge.vb.x)<1e-9 && abs_fn(edge.va.y-edge.vb.y)<1e-9)) {
             edge.va = edge.vb = null;
-            edges.splice(iEdge,1);
             } else {
             newEdges.unshift(edge);
             }


### PR DESCRIPTION
Hi! 
making some tests I've noticed a huge performance issue using more than 16k sites (2*14+ for precision sake). Making some profiling it results that  the splice in clipEdges() slow down a lot with large arrays (from 0.3s for 12k points to 4s for 16k). I've removed de splice, making a new array with unshift and now it take 0.35 for 16k sites and 1.5s for 65k.
hope this fix can be helpful :)
thanks a lot for your work ;)